### PR TITLE
Make datasets preprocessing optional

### DIFF
--- a/downstream/README.md
+++ b/downstream/README.md
@@ -207,23 +207,58 @@ Specified by the command `-d asr`
 
 #### Prepare data
 
-1. To download the train, validation, and test splits and compute the utterance lengths, run:
+There are two ways to prepare the data for this task:
+
+* The default implementation in `s3prl`
+* The implementation based on the Hugging Face Datasets library
+
+##### Preparation with s3prl
+
+1. Download [LibriSpeech](https://www.openslr.org/12) and unzip. Only need train-clean-100, dev-clean, and test-clean.
+
+2. Check the prepared file structure
 
     ```bash
-    python preprocess/generate_len_for_bucket.py -o data/Librispeech --n_jobs 12
+    LibriSpeech/
+    ├── train-clean-100/
+    ├── dev-clean/
+    └── test-clean/
     ```
 
-This will download the LibriSpeech subsets from the [`superb` dataset](https://huggingface.co/datasets/superb) on the Hugging Face Hub and store them in `~/.cache/huggingface/datasets/superb/asr`
-
-**TODO:** Verify whether we need to configure the step below to sync with the `cache_dir` of `datasets`.
-
-2. Change the path in `downstream/asr/config.yaml`
+3. Change the path in `downstream/asr/config.yaml`
 
     ```yaml
     downstream_expert:
         datarc:
             libri_root: "root directory of LibriSpeech"
     ```
+
+4. Prepare the lengths for utterances in LibriSpeech's train-clean-100, dev-clean and test-clean:
+
+    ```bash
+    # Official LibriSpeech is in .flac format
+    python3 preprocess/generate_len_for_bucket.py -i "root directory of LibriSpeech" -o data/librispeech -a .flac --n_jobs 12
+    ```
+
+##### Preparation with Hugging Face Datasets
+
+To download the train, validation, and test splits and compute the utterance lengths, run:
+
+```bash
+python preprocess/generate_len_for_bucket.py -o data/Librispeech --n_jobs 12 --use_datasets True
+```
+
+This will download the LibriSpeech subsets from the [`superb` dataset](https://huggingface.co/datasets/superb) on the Hugging Face Hub and store them in `~/.cache/huggingface/datasets/superb/asr`
+
+**TODO:** Verify whether we need to configure the step below to sync with the `cache_dir` of `datasets`.
+
+Change the path in `downstream/asr/config.yaml`
+
+```yaml
+downstream_expert:
+    datarc:
+        libri_root: "root directory of LibriSpeech"
+```
 
 #### Training
 


### PR DESCRIPTION
This PR reinstates the `s3prl` preprocessing functionality and adds a flag to toggle between this and the `datasets` approach implemented in #1 

cc @osanseviero 